### PR TITLE
[98] Prepare retained logs for deferred processing

### DIFF
--- a/girders-libs/girders-logging/src/main/java/com/netcetera/girders/logging/RetainingAppender.java
+++ b/girders-libs/girders-logging/src/main/java/com/netcetera/girders/logging/RetainingAppender.java
@@ -92,6 +92,7 @@ public final class RetainingAppender extends AppenderBase<ILoggingEvent> impleme
   }
 
   private synchronized void retain(ILoggingEvent logEvent) {
+    logEvent.prepareForDeferredProcessing();
     buffer.add(logEvent);
   }
 

--- a/girders-libs/girders-logging/src/test/java/com/netcetera/girders/logging/BufferingAppender.java
+++ b/girders-libs/girders-logging/src/test/java/com/netcetera/girders/logging/BufferingAppender.java
@@ -2,26 +2,31 @@ package com.netcetera.girders.logging;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.AppenderBase;
-import com.google.common.base.Joiner;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.stream.Collectors;
 
 class BufferingAppender extends AppenderBase<ILoggingEvent> {
 
-  private final Collection<String> buffer = new ArrayList<>(10);
+  private final Collection<ILoggingEvent> buffer = new ArrayList<>(10);
 
   void clear() {
     buffer.clear();
   }
 
   String dumpCsv() {
-    return Joiner.on(", ").join(buffer);
+    return buffer.stream().map(ILoggingEvent::getMessage).collect(Collectors.joining(", "));
+  }
+
+  Collection<ILoggingEvent> getLoggingEvents() {
+    return Collections.unmodifiableCollection(buffer);
   }
 
   @Override
   public void append(ILoggingEvent logEvent) {
-    buffer.add(logEvent.getMessage());
+    buffer.add(logEvent);
   }
 
 }

--- a/girders-libs/girders-logging/src/test/java/com/netcetera/girders/logging/RetainingAppenderTest.java
+++ b/girders-libs/girders-logging/src/test/java/com/netcetera/girders/logging/RetainingAppenderTest.java
@@ -28,6 +28,9 @@ class RetainingAppenderTest {
   @BeforeEach
   void init() {
     LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+    // Resetting the context is necessary because Logback's BasicConfigurator initializes a ConsoleAppender which
+    // introduces unexpected side effects.
+    context.reset();
 
     // loggers
     ch.qos.logback.classic.Logger logger = context.getLogger(TEST_APPENDER_NAME);
@@ -85,10 +88,6 @@ class RetainingAppenderTest {
     assertThat(appenderContent, not(containsString("DEBUG" + suffix)));
   }
 
-  private String getBufferAppenderContent() {
-    return bufferingAppender.dumpCsv();
-  }
-
   @Test
   void shouldDumpDebugEventOnceErrorOccurred() {
     // given testLogger setup plus...
@@ -115,7 +114,7 @@ class RetainingAppenderTest {
   }
 
   @Test
-  void shouldSupportAppenderAttacheableMethods() {
+  void shouldSupportAppenderAttachableMethods() {
     RetainingAppender retainingAppender = new RetainingAppender();
     assertThat(retainingAppender.iteratorForAppenders().hasNext(), is(false));
     assertThat(retainingAppender.isAttached(bufferingAppender), is(false));
@@ -150,6 +149,10 @@ class RetainingAppenderTest {
     assertThat(retainingAppender.iteratorForAppenders().hasNext(), is(false));
     assertThat(retainingAppender.isAttached(bufferingAppender), is(false));
     assertThat(retainingAppender.getAppender(TEST_APPENDER_NAME), is(nullValue()));
+  }
+
+  private String getBufferAppenderContent() {
+    return bufferingAppender.dumpCsv();
   }
 
 }

--- a/girders-libs/girders-logging/src/test/java/com/netcetera/girders/logging/RetainingAppenderTest.java
+++ b/girders-libs/girders-logging/src/test/java/com/netcetera/girders/logging/RetainingAppenderTest.java
@@ -2,13 +2,29 @@ package com.netcetera.girders.logging;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import lombok.RequiredArgsConstructor;
+import org.assertj.core.util.Lists;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -113,6 +129,55 @@ class RetainingAppenderTest {
     assertThat(appenderContent, containsString("ERROR" + suffix));
   }
 
+  /**
+   * Tests whether the lazily-initialized log event context has been captured for the retained logs.
+   * <p>
+   * Refer to {@link LoggingEvent#prepareForDeferredProcessing()} for a comprehensive overview of the
+   * lazily initialized logging event fields.
+   */
+  @Test
+  void shouldPopulateLazilyInitializedFieldsForDeferredProcessing() throws InterruptedException {
+    // given testLogger setup plus...
+    String suffix = " test dump";
+    String traceLogThreadName = "thread-2";
+    String mdcKey = "key";
+    String debugLogMdcValue = "debug-log-value";
+    String warnLogMdcValue = "warn-log-value";
+
+    // when
+    Thread t = new Thread(() -> testLogger.trace("TRACE" + suffix), traceLogThreadName);
+    t.start();
+    t.join();
+
+    MDC.put(mdcKey, debugLogMdcValue);
+    testLogger.debug("DEBUG" + suffix);
+
+    MDC.put(mdcKey, warnLogMdcValue);
+    testLogger.warn("WARN" + suffix);
+    testLogger.error("ERROR" + suffix);
+
+    String appenderContent = getBufferAppenderContent();
+    System.err.println("appender content = " + appenderContent);
+
+    // then
+    // Expected lazily-initialized contexts of non-retained logs
+    LazilyInitializedContext warnEventContext = LazilyInitializedContext.withCurrentThreadName()
+        .addMdcProperty(mdcKey, warnLogMdcValue);
+    LazilyInitializedContext errorEventContext = LazilyInitializedContext.withCurrentThreadName()
+        .addMdcProperty(mdcKey, warnLogMdcValue);
+
+    // Expected lazily-initialized contexts of dumped retained logs
+    LazilyInitializedContext dumpInfoEventContext = LazilyInitializedContext.withCurrentThreadName()
+        .addMdcProperty(mdcKey, warnLogMdcValue);
+    LazilyInitializedContext traceEventContext = LazilyInitializedContext.withThreadName(traceLogThreadName);
+    LazilyInitializedContext debugEventContext = LazilyInitializedContext.withCurrentThreadName()
+        .addMdcProperty(mdcKey, debugLogMdcValue);
+
+    List<ILoggingEvent> logEvents = Lists.newArrayList(getBufferAppenderLogEvents().iterator());
+    assertThat(logEvents, containsLazilyInitializedContext(warnEventContext, errorEventContext, dumpInfoEventContext,
+        traceEventContext, debugEventContext));
+  }
+
   @Test
   void shouldSupportAppenderAttachableMethods() {
     RetainingAppender retainingAppender = new RetainingAppender();
@@ -155,4 +220,60 @@ class RetainingAppenderTest {
     return bufferingAppender.dumpCsv();
   }
 
+  private Collection<ILoggingEvent> getBufferAppenderLogEvents() {
+    return bufferingAppender.getLoggingEvents();
+  }
+
+  private static Matcher<? super List<ILoggingEvent>> containsLazilyInitializedContext(
+      LazilyInitializedContext... contexts) {
+    List<Matcher<? super ILoggingEvent>> matchers = Arrays.stream(contexts)
+        .<Matcher<? super ILoggingEvent>>map(ContextMatcher::new)
+        .toList();
+    return contains(matchers);
+  }
+
+  @RequiredArgsConstructor
+  private static class ContextMatcher extends TypeSafeMatcher<ILoggingEvent> {
+
+    private final LazilyInitializedContext expectedContext;
+
+    @Override
+    protected boolean matchesSafely(ILoggingEvent actualLoggingEvent) {
+      return Objects.equals(expectedContext.mdcProperties(), actualLoggingEvent.getMDCPropertyMap())
+          && Objects.equals(expectedContext.threadName(), actualLoggingEvent.getThreadName());
+    }
+
+    @Override
+    public void describeTo(Description description) {
+      description.appendValue(expectedContext);
+    }
+
+    @Override
+    protected void describeMismatchSafely(ILoggingEvent actualLoggingEvent, Description mismatchDescription) {
+      mismatchDescription.appendValue("with log message '%s' has '%s'".formatted(actualLoggingEvent,
+          new LazilyInitializedContext(actualLoggingEvent.getMDCPropertyMap(), actualLoggingEvent.getThreadName())));
+    }
+  }
+
+  /**
+   * Helper POJO describing the lazily-initialized {@link LoggingEvent} fields.
+   *
+   * @param mdcProperties the {@link MDC} properties of the {@link LoggingEvent}.
+   * @param threadName the {@link Thread#getName() thread name} of the {@link LoggingEvent}.
+   */
+  private record LazilyInitializedContext(Map<String, String> mdcProperties, String threadName) {
+
+    static LazilyInitializedContext withThreadName(String threadName) {
+      return new LazilyInitializedContext(new HashMap<>(), threadName);
+    }
+
+    static LazilyInitializedContext withCurrentThreadName() {
+      return new LazilyInitializedContext(new HashMap<>(), Thread.currentThread().getName());
+    }
+
+    LazilyInitializedContext addMdcProperty(String key, String value) {
+      mdcProperties.put(key, value);
+      return this;
+    }
+  }
 }


### PR DESCRIPTION
#### Description of changes
Resolves #98.

* Resets the logger context to remove existing appenders.
  * Currently, the ROOT logger has a `ConsoleAppender` attached, which introduces side effects that can interfere with testing the `RetainingAppender`.
* Prepares retained logs for deferred processing as documented in [`LoggingEvent.html#prepareForDeferredProcessing()`](https://logback.qos.ch/apidocs/ch.qos.logback.classic/ch/qos/logback/classic/spi/LoggingEvent.html#prepareForDeferredProcessing())